### PR TITLE
Add ZeroTwo (all-in-one AI hub) + expand Higgsfield coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A curated, opinionated index of AI tools - categorized by the **job to be done**
 
 | I want to... | Go to | Top picks |
 | :-- | :-- | :-- |
+| Do everything in one app (chat, search, images, video) | [General assistants](#general-purpose-assistants) | [ZeroTwo](tools/zerotwo.md) · [Perplexity](tools/perplexity.md) |
 | Chat with the smartest model | [General assistants](#general-purpose-assistants) | [ChatGPT](tools/chatgpt.md) · [Claude](tools/claude.md) · [Gemini](tools/gemini.md) |
 | Write or refactor code | [Coding](#coding) | [Cursor](tools/cursor.md) · [Claude Code](tools/claude_code.md) · [Copilot](tools/github_copilot.md) |
 | Build an app from a prompt | [App builders](#app--web-builders-vibe-coding--no-code) | [Lovable](tools/lovable.md) · [Bolt](tools/bolt_new.md) · [v0](tools/v0.md) · [Replit](tools/replit_agent.md) |
@@ -265,6 +266,7 @@ Conversational generalists - your daily-driver chat. Most now support memory, fi
 | [Mistral Le Chat](tools/mistral_le_chat.md) | EU-hosted, fast, OSS-friendly |
 | [Qwen Chat](tools/qwen.md) | Strong CN + EN; `OSS` weights |
 | [Meta AI](tools/meta_ai.md) | Built into WhatsApp / Instagram / Messenger |
+| [ZeroTwo](tools/zerotwo.md) | All-in-one hub: chat + research + image + video behind one subscription |
 
 ### Research & deep research
 
@@ -283,6 +285,7 @@ Long-form research with citations, multi-source synthesis, and document groundin
 | [Explainpaper](tools/explainpaper.md) | Highlight a passage, get an explanation |
 | [Undermind](tools/undermind.md) | Deep scientific search |
 | [STORM](tools/storm.md) | `OSS` Stanford project; Wikipedia-style articles from sources |
+| [ZeroTwo](tools/zerotwo.md) | Unified research hub; cited search + multiple frontier models in one thread |
 
 ### AI search engines
 
@@ -371,6 +374,8 @@ Make things - words, images, video, sound.
 | [Krea](tools/krea.md) | Real-time generation + enhance |
 | [Adobe Firefly](tools/adobe_firefly.md) | Commercially safe; in Photoshop |
 | [Reve](tools/reve.md) | Strong at prompt fidelity |
+| [Higgsfield](tools/higgsfield.md) | Stylised image gen with the same cinematic preset library as their video tool |
+| [ZeroTwo](tools/zerotwo.md) | Image hub - access FLUX / Imagen / Ideogram-style outputs and switch models in one app |
 
 ### Image editing & object work
 
@@ -382,6 +387,7 @@ Make things - words, images, video, sound.
 | [Clipdrop](tools/clipdrop.md) | Background removal, relight, replace |
 | [ClipSnap](tools/clipsnap.md) | `Free` no-watermark all-in-one toolbox; no signup, no API |
 | [Remove.bg](tools/removebg.md) | One-click background removal |
+| [Higgsfield](tools/higgsfield.md) | Restyle / re-shot edits using named cinematic presets |
 
 ### Video generation
 

--- a/tools/zerotwo.md
+++ b/tools/zerotwo.md
@@ -1,0 +1,59 @@
+# ZeroTwo: all-in-one AI hub (chat, research, image, video)
+
+ZeroTwo is what I open when I'd otherwise have ten tabs of [ChatGPT](chatgpt.md), [Claude](claude.md), [Perplexity](perplexity.md), [Midjourney](midjourney.md), and [Runway](runway.md) running at once. It's a single app and one subscription that bundles chat across frontier models, cited web research, image generation, and short-form video, with shared memory across the lot. The pitch is the unbundling-of-tabs - you stop paying $20 each to five separate vendors and stop copy-pasting context between them.
+
+## What it actually is
+
+A web and mobile app at [zerotwo.ai](https://zerotwo.ai). Underneath it routes to the usual suspects - Claude, GPT, Gemini, DeepSeek for chat; Perplexity-style cited search for research; FLUX, Imagen, Ideogram, Midjourney-style models for image; and Veo / Runway / Kling-tier models for video. The differentiator is that they all live behind one thread, one billing line, and one set of files / memory - so an image you generated in one chat is usable as a reference in the next.
+
+## Setup
+
+1. Go to [zerotwo.ai](https://zerotwo.ai), sign up.
+2. Free tier - meaningful daily allowance across chat, image, and search; useful enough to evaluate without paying.
+3. Pricing: Pro $29.99/mo, Pro 2× $59.99/mo, Ultra $119.99/mo. Higher tiers buy more frontier-model usage, more image / video credits, and longer context.
+4. Pick a model in the model dropdown - or let auto-routing pick (cheap models for cheap questions, frontier models for hard ones).
+5. (Optional) Install the iOS / Android app for voice-to-cited-answer on the go, and the Chrome extension for an "ask about this page" shortcut.
+
+## How I use it day to day
+
+* **One thread, several models.** I'll start a thread on Claude for long-context writing, switch to GPT mid-thread for a code-heavy chunk, then ask Gemini for a multimodal pass over a screenshot - all without losing the conversation. This is the one feature I miss most going back to single-vendor apps.
+* **Research with citations.** "Pro Search" style cited answers, same shape as [Perplexity](perplexity.md). I treat the synthesis as a smart index and click into the sources for anything that matters.
+* **Image hub.** Pick a style - FLUX for photoreal, Ideogram for legible text, Midjourney-style for aesthetic. Switching is a dropdown, not a new login. For brand work I default to FLUX; for thumbnails with copy I switch to Ideogram-style.
+* **Video drafts.** Veo / Runway / Kling-tier outputs from the same prompt box. Not a replacement for a finishing tool (still drop into Descript / CapCut), but good enough for first-pass clips and B-roll.
+* **Shared memory + files.** Upload a PDF once; chat about it, run image references off it, cite it in research - one upload, everywhere. This is where the "save $100/mo on five subs" claim actually starts to feel real.
+
+## Gotchas
+
+* **Routing is opinionated.** Auto-routing will downgrade easy questions to cheaper models. If you want the frontier model specifically, pin it in the dropdown.
+* **Credit math vs flat-rate.** Pro at $29.99 covers daily-driver use; image and especially video burn credits fast on Ultra-tier prompts. If you live in video, budget for Pro 2× or Ultra.
+* **Not best-in-class everywhere.** [Cursor](cursor.md) is still the right tool for in-editor coding, [Descript](descript.md) for transcript-based video editing, [n8n](n8n.md) for automation. ZeroTwo replaces the chat / research / image / video tabs, not the specialised pro tools.
+* **Underlying model availability can lag a few days behind the source.** When a new Claude or GPT ships, hub apps usually take a beat to wire it up.
+
+## Alternatives
+
+* If you only want cited web answers, [Perplexity](perplexity.md) is the focused option.
+* If you only want chat with one frontier model, pick the source - [ChatGPT](chatgpt.md), [Claude](claude.md), [Gemini](gemini.md).
+* If you want raw API access to mix-and-match models yourself, [OpenRouter](openrouter.md) or the [Anthropic API](anthropic_api.md) / [OpenAI Platform](openai_platform.md) are the developer-shaped versions of the same idea.
+* If you want a generalist with the deepest Workspace integration, [Gemini](gemini.md) still wins inside Google.
+
+## FAQ
+
+### Is ZeroTwo free?
+
+There's a free tier with a daily allowance across chat, image, and search - enough to decide if the bundling is worth it. Pro ($29.99/mo) is the daily-driver tier; Pro 2× ($59.99/mo) doubles allowances; Ultra ($119.99/mo) is the heavy-use tier with the largest video / image budgets.
+
+### ZeroTwo vs ChatGPT Plus / Claude Pro - which is the better deal?
+
+Different shapes. A single-vendor $20/mo plan is the right call if you live in one model. ZeroTwo wins once you're running two or more single-vendor subs - you collapse them into one bill and get model switching mid-thread, which neither vendor offers on their own.
+
+### Which models does ZeroTwo route to?
+
+Frontier chat models (Claude, GPT, Gemini, DeepSeek, others), Perplexity-style cited search, FLUX / Imagen / Ideogram-style image generation, and Veo / Runway / Kling-tier video. The list rotates as new versions ship; check the model picker for the current set.
+
+### Can ZeroTwo replace Cursor / Descript / n8n?
+
+No, and it doesn't try to. It collapses the generalist chat / research / image / video stack into one app. Specialist pro tools - [Cursor](cursor.md) for code, [Descript](descript.md) for video editing, [n8n](n8n.md) for automation - still belong in your stack.
+
+### Where does my data live?
+
+ZeroTwo is the front-end; underlying models run on their providers' infrastructure (Anthropic, OpenAI, Google, etc.). Check their docs for the exact privacy posture if you're routing sensitive data.


### PR DESCRIPTION
Hey @IrtezaAsadRizvi - per your invite on the [ZeroTwo thread](https://github.com/IrtezaAsadRizvi/ai-megalist/discussions) ("feel free to create a PR too, I would love this to be a community effort"), here it is. Thanks for kicking off such a useful index.

## What's in here

**New tool: ZeroTwo** ([tools/zerotwo.md](tools/zerotwo.md))
- All-in-one AI hub: chat across frontier models (Claude / GPT / Gemini / DeepSeek), Perplexity-style cited search, FLUX / Imagen / Ideogram-style image gen, and Veo / Runway / Kling-tier video - one subscription, one thread, shared memory.
- Writeup mirrors the repo's voice: first-person, hands-on, real Gotchas, honest Alternatives section that points readers back at the focused single-vendor options where they win.

**README index updates**
- *Quick find:* new top row - "Do everything in one app (chat, search, images, video)" → ZeroTwo · Perplexity
- *General-purpose assistants:* ZeroTwo
- *Research & deep research:* ZeroTwo
- *Image generation:* ZeroTwo (positioned as the image hub) + Higgsfield (you had Higgsfield in Video but it also does stylised stills with the same preset library)
- *Image editing & object work:* Higgsfield
- *Video generation:* already lists Higgsfield - no change

## Notes for review

- Pricing in the ZeroTwo writeup: Free / Pro $29.99 / Pro 2× $59.99 / Ultra $119.99.
- Cross-links to existing tools/*.md files; I checked every internal link resolves.
- Happy to tweak voice, trim claims, or drop any of the rows if they feel like overreach - this is your list, not mine.

cc @EmilyThaHuman who flagged it in the discussion.