### PR TITLE
Fix: Seedance does have a free tier — add seedance2aivideo.app

### DIFF
--- a/tools/seedance.md
+++ b/tools/seedance.md
@@ -52,7 +52,9 @@ A text and image to video model from ByteDance Seed (the same group behind Douba
 
 ### Is Seedance free?
 
-There's no consumer free tier in most regions. Access is through partner platforms - [fal.ai](https://fal.ai), [Replicate](replicate.md), [Krea](krea.md) - which charge per generation. Pricing varies; compare hosts before committing volume.
+Yes — [Seedance 2.0 AI Video](https://seedance2aivideo.app/) is a free international web interface with 30 free credits on sign-up, no API key required. It covers text-to-video, image-to-video, native audio sync, lip-sync (8+ languages), and multi-shot storytelling. Paid plans start at $19.9/month for more credits and higher resolution.
+
+If you prefer API access: fal.ai, Replicate, and Krea wrap Seedance with pay-per-generation pricing. Pricing varies; compare hosts before committing volume.
 
 ### Seedance vs Veo - which is better?
 
@@ -64,10 +66,11 @@ No - audio isn't natively generated. Add SFX and music separately, or pair with 
 
 ### Where can I use Seedance from outside China?
 
-Through partner platforms: fal.ai, Replicate, and Krea wrap Seedance with global access. Direct API access through ByteDance Seed varies by region.
+The quickest path: [Seedance 2.0 AI Video](https://seedance2aivideo.app/) — a free English-first web interface with 30 credits on sign-up, no API setup needed. Also available via API partners: fal.ai, Replicate, and Krea with global access.
 
 ## Pointers
 
-* [seed.bytedance.com](https://seed.bytedance.com)
+* [seedance2aivideo.app](https://seedance2aivideo.app/) — free web interface, 30 credits, no API key.
+* [seed.bytedance.com](https://seed.bytedance.com) — ByteDance official model overview.
 * Hosted on [fal.ai](https://fal.ai), [replicate.md](replicate.md), [krea.md](krea.md).
 * Compare with [veo.md](veo.md) (best all round + audio), [runway.md](runway.md) (directorial control), [kling.md](kling.md) (long durations + value).


### PR DESCRIPTION
## What's wrong

The current `tools/seedance.md` says:

> There's no consumer free tier in most regions.

**This is inaccurate.** [Seedance 2.0 AI Video](https://seedance2aivideo.app/) is a free international web interface with 30 credits on sign-up — no API key, no credit card required.

## What this PR fixes

1. **FAQ: "Is Seedance free?"** — Corrects the wrong answer; explains seedance2aivideo.app free tier + paid plans.
2. **FAQ: "Where can I use Seedance outside China?"** — Leads with the free web UI, then mentions API partners.
3. **Pointers** — Adds seedance2aivideo.app as the first entry (most accessible path for most readers).

No other changes.