### PR TITLE
Add igly.ai image editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A curated, opinionated index of AI tools - categorized by the **job to be done**
 | Read & question my own PDFs | [Research](#research--deep-research) | [NotebookLM](tools/notebooklm.md) · [SciSpace](tools/scispace.md) |
 | Run a multi-step research task | [Research](#research--deep-research) | [ChatGPT Deep Research](tools/chatgpt.md) · [Gemini DR](tools/gemini.md) |
 | Generate an image | [Image](#image-generation) | [Midjourney](tools/midjourney.md) · [Flux](tools/flux.md) · [Ideogram](tools/ideogram.md) |
-| Edit / upscale an image | [Image editing](#image-editing--object-work) | [Photoshop GenFill](tools/photoshop_genfill.md) · [Magnific](tools/magnific.md) |
+| Edit / upscale an image | [Image editing](#image-editing--object-work) | [Photoshop GenFill](tools/photoshop_genfill.md) · [Magnific](tools/magnific.md) · [igly.ai](tools/igly.md) |
 | Generate a video | [Video](#video-generation) | [Veo 3.1](tools/veo.md) · [Runway](tools/runway.md) · [Kling](tools/kling.md) |
 | Edit / repurpose video | [Video editing](#video-editing--repurposing) | [Descript](tools/descript.md) · [Opus Clip](tools/opus_clip.md) · [Captions](tools/captions.md) |
 | Clone a voice / dub | [Voice](#voice--speech) | [ElevenLabs](tools/elevenlabs.md) · [Cartesia](tools/cartesia.md) |
@@ -155,7 +155,7 @@ A curated, opinionated index of AI tools - categorized by the **job to be done**
 | Prompt → React / Tailwind | **[v0](tools/v0.md)** | [Magic Patterns](tools/magic_patterns.md) |
 | Brand visuals | **[Recraft](tools/recraft.md)** | [Adobe Firefly](tools/adobe_firefly.md) · [Canva](tools/canva.md) |
 | Mood / concept boards | **[Midjourney](tools/midjourney.md)** | [Krea](tools/krea.md) · [Leonardo](tools/leonardo.md) |
-| Photo edit / inpaint | **[Photoshop Generative Fill](tools/photoshop_genfill.md)** | [Magnific](tools/magnific.md) · [Clipdrop](tools/clipdrop.md) |
+| Photo edit / inpaint | **[Photoshop Generative Fill](tools/photoshop_genfill.md)** | [Magnific](tools/magnific.md) · [Clipdrop](tools/clipdrop.md) · [igly.ai](tools/igly.md) |
 | Client decks | **[Gamma](tools/gamma.md)** | [Tome](tools/tome.md) |
 
 <sub>→ Deeper: [Design](#design-uiux-graphics-presentations) · [Image](#image-generation)</sub>
@@ -390,6 +390,7 @@ Make things - words, images, video, sound.
 | [Magnific](tools/magnific.md) | AI upscaling + relight |
 | [Topaz Photo AI](tools/topaz_photo.md) | Pro denoise / upscale |
 | [Clipdrop](tools/clipdrop.md) | Background removal, relight, replace |
+| [igly.ai](tools/igly.md) | Browser-based background removal, inpainting, upscaling, and generative fill |
 | [ClipSnap](tools/clipsnap.md) | `Free` no-watermark all-in-one toolbox; no signup, no API |
 | [Remove.bg](tools/removebg.md) | One-click background removal |
 | [TinyTools](https://tinytools-smoky.vercel.app/) | `Free` all-in-one browser toolbox: local background removal (WASM, fully offline), OG image gen, SEO tags, favicon, color palette, domain generator + AI cost calculator; no signup |

--- a/tools/igly.md
+++ b/tools/igly.md
@@ -1,0 +1,57 @@
+# igly.ai: fast AI image edits for product and creator workflows
+
+igly.ai sits in the image editing category alongside [Clipdrop](clipdrop.md), [Remove.bg](removebg.md), and [Photoshop Generative Fill](photoshop_genfill.md). It is a browser-based editor for practical AI image work: background removal, inpainting, upscaling, and generative fill without needing a full Photoshop workflow. The best fit is creators, marketers, and ecommerce teams who need quick product or campaign visuals rather than a heavyweight layer-based editor.
+
+## What it actually is
+
+A web app at [igly.ai](https://igly.ai) for AI-assisted image editing. Core jobs include:
+* Background removal for product photos and social images.
+* Inpainting / object cleanup.
+* Image upscaling.
+* Generative fill for extending or replacing parts of an image.
+
+## Setup
+
+1. Go to [igly.ai](https://igly.ai).
+2. Upload an image.
+3. Pick the edit type: remove background, inpaint, upscale, or generative fill.
+4. Preview the result and download.
+
+## How I use it day to day
+
+* **Product-image cleanup.** Remove backgrounds or distracting objects from ecommerce photos before publishing.
+* **Campaign visuals.** Generate or extend image areas for social ads, landing pages, and thumbnails.
+* **Fast iteration.** Try edits in the browser before moving anything into a heavier design tool.
+* **Upscaling.** Improve low-resolution assets when the source image is good enough to recover.
+
+## Gotchas
+
+* It is a focused web workflow, not a full replacement for Photoshop, Affinity, or a local ComfyUI setup.
+* Inpainting and generative fill quality still depends on the source image, prompt clarity, and how complex the masked area is.
+* For high-volume API-only background removal, a single-purpose tool like [Remove.bg](removebg.md) may still be simpler.
+
+## Alternatives
+
+* If you need layer-based professional compositing, use [Photoshop Generative Fill](photoshop_genfill.md).
+* If you want a broader one-click toolbox, compare [Clipdrop](clipdrop.md).
+* If you only need background removal, [Remove.bg](removebg.md) is the specialist.
+* If you need pro denoise and restoration, [Topaz Photo AI](topaz_photo.md) is the photographer-focused option.
+
+## FAQ
+
+### What is igly.ai best for?
+
+Fast browser-based AI image edits: product photo cleanup, background removal, inpainting, upscaling, and generative fill.
+
+### Is igly.ai only for ecommerce?
+
+No. Ecommerce product photos are a natural fit, but the same workflow works for creators, marketers, and designers preparing campaign visuals.
+
+### Where can I see it in action?
+
+The project has a short demo on YouTube: [igly.ai demo](https://www.youtube.com/watch?v=HB2E1WZ12is).
+
+## Pointers
+
+* [igly.ai](https://igly.ai)
+* Demo: [youtube.com/watch?v=HB2E1WZ12is](https://www.youtube.com/watch?v=HB2E1WZ12is)


### PR DESCRIPTION
## Summary
- Add igly.ai as a browser-based AI image editor for background removal, inpainting, upscaling, and generative fill
- Link it from the image editing table and designer/photo-editing workflows
- Include the product demo reference: https://www.youtube.com/watch?v=HB2E1WZ12is

## Notes
igly.ai fits the existing Image editing & object work section alongside Clipdrop, Remove.bg, and Photoshop Generative Fill.