### PR TITLE
feat: add CreatorSkills to Content Creator section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ A curated, opinionated index of AI tools - categorized by the **job to be done**
 
 | Job | Default | Alternates |
 | :-- | :-- | :-- |
-| Scripting + ideation | **[Claude](tools/claude.md)** / **[ChatGPT](tools/chatgpt.md)** | [Gemini](tools/gemini.md) |
+| Scripting + ideation | **[Claude](tools/claude.md)** / **[ChatGPT](tools/chatgpt.md)** | [Gemini](tools/gemini.md) · [CreatorSkills](tools/creatorskills.md) *(skill packs for YouTube scripting, sponsorships, audience growth)* |
 | Text → video | **[Veo 3.1](tools/veo.md)** | [Runway](tools/runway.md) · [Kling](tools/kling.md) · [Pika](tools/pika.md) |
 | Edit by transcript | **[Descript](tools/descript.md)** | [CapCut](tools/capcut.md) |
 | Short-form clips from a podcast | **[Opus Clip](tools/opus_clip.md)** | [Captions](tools/captions.md) · [Submagic](tools/submagic.md) · [Klap](tools/klap.md) |

--- a/tools/creatorskills.md
+++ b/tools/creatorskills.md
@@ -1,0 +1,34 @@
+# CreatorSkills: AI skill marketplace for content creators
+
+CreatorSkills is a marketplace of 30+ downloadable AI skill files for content creators — covering YouTube scripting, sponsorship analysis, audience growth, and more. Skills install into Claude and ChatGPT, turning a general-purpose model into a specialist tool tuned for your creator workflow.
+
+## What it actually is
+
+A paid marketplace at [creatorskills.co](https://creatorskills.co) where you buy SKILL.md (Agent Skills format) or .mdc (Cursor format) files that snap into Claude or ChatGPT as persistent instructions. Each skill targets a specific creator job: writing hooks and scripts for YouTube, analyzing brand deals, repurposing long-form content, building audience personas, designing course curricula, and more. You install the skill once and it's there every session, no re-prompting required.
+
+## How it works
+
+1. Browse skills by category (scripting, titles & thumbnails, audience growth, sponsorships, course creation).
+2. Purchase and download the skill file (SKILL.md or .mdc).
+3. Install into Claude Code, Cursor, or your AI client of choice.
+4. The skill becomes a persistent assistant for that job — run it on demand via a slash command.
+
+## When to use CreatorSkills vs raw Claude / ChatGPT
+
+| Situation | Recommendation |
+| :-- | :-- |
+| One-off script draft | Raw Claude / ChatGPT is fine |
+| Recurring scripting workflow with consistent format | CreatorSkills scripting skill |
+| Need to evaluate a sponsorship deal quickly | CreatorSkills sponsorship analysis skill |
+| Building a YouTube channel systematically | CreatorSkills audience + titles + scripting bundle |
+
+## Alternatives
+
+- [Claude](claude.md) / [ChatGPT](chatgpt.md) — the models CreatorSkills skills run on; use directly for one-offs.
+- [Jasper](jasper.md) — broader marketing platform with its own brand-voice system; not creator-specific.
+
+## Pointers
+
+- Web: [creatorskills.co](https://creatorskills.co)
+- Skill format: Agent Skills open standard (SKILL.md) + Cursor (.mdc)
+- Compatible with: Claude (all versions), ChatGPT (via custom instructions), Claude Code


### PR DESCRIPTION
## What this adds

[CreatorSkills](https://creatorskills.co) — a marketplace of 30+ downloadable AI skill files for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.

## Changes

- `README.md`: adds CreatorSkills as an alternate in the Content Creator → Scripting + ideation row
- `tools/creatorskills.md`: new full writeup following the existing tool format

## Why it fits

The Content Creator section's Scripting + ideation row currently shows Claude/ChatGPT as defaults. CreatorSkills runs *on top of* those models, giving creators pre-built skill files for their specific jobs (YouTube hooks, sponsorship analysis, audience persona building) that install once and persist across sessions — the "skill libraries" complement to the underlying LLM.