### PR TITLE
Add Gemini Omni to video generation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Make things - words, images, video, sound.
 | [Pixverse](tools/pixverse.md) | Anime / stylized motion |
 | [HunyuanVideo](tools/hunyuan_video.md) | `OSS` Tencent's 13B video model; ComfyUI / LoRA-friendly |
 | [Wan 2.x](tools/wan.md) | `OSS` Alibaba; Apache 2.0; strong motion at small + big sizes |
+| [Gemini Omni](https://gemini-omni.pro) | `Free` Google omni-modal model; text, image, video & audio in one prompt; native audio sync; free 720p |
 
 > ⚠️ **Heads up (April 2026):** OpenAI's Sora consumer apps shut down on **2026-04-26**; the API follows on **2026-09-24**.
 


### PR DESCRIPTION
## Summary

Adds **Gemini Omni** (https://gemini-omni.pro) to the `### Video generation` table, placed after the Wan 2.x entry.

| Field | Value |
|---|---|
| Name | Gemini Omni |
| URL | https://gemini-omni.pro |
| Tier | Free |
| Description | Google omni-modal model; text, image, video & audio in one prompt; native audio sync; free 720p |

Gemini Omni is a free AI video generator powered by Google's omni-modal model that accepts text, image, video, and audio in a single prompt with native audio sync.