### PR TITLE
Add Hermes to Real-time conversation & voice agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Make things - words, images, video, sound.
 | Tool | Best for |
 | :-- | :-- |
 | [Vapi](tools/vapi.md) · [Retell](tools/retell.md) · [Bland](https://www.bland.ai) | Build phone-call voice agents |
+| [Hermes](https://www.buildwithhermes.com) | White-label platform for agencies running client voice agents (CRM + campaigns built in) |
 | [LiveKit Agents](tools/livekit.md) | `OSS` voice agent framework |
 
 ### Music generation


### PR DESCRIPTION
One row added to the Real-time conversation & voice agents sub-section, per the contributing format (one tool per row, one-line best-for).

The sub-section currently covers building phone voice agents (Vapi, Retell, Bland) and the OSS framework layer (LiveKit). Hermes covers a different slot: agencies that run voice agents for multiple clients and need white-label workspaces, a native CRM, and campaign orchestration on top of the agent itself. Distinct enough from the builder row that readers picking a tool by role will want it listed.

Public pricing from $149/mo, no affiliate link.