### PR TITLE
Add Rao Edits to image generation and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Make things - words, images, video, sound.
 | [Reve](tools/reve.md) | Strong at prompt fidelity |
 | [Higgsfield](tools/higgsfield.md) | Stylised image gen with the same cinematic preset library as their video tool |
 | [ZeroTwo](tools/zerotwo.md) | Image hub - access FLUX / Imagen / Ideogram-style outputs and switch models in one app |
+| [Rao Edits](tools/rao_edits.md) | Browser-based text-to-image generation for creator and marketing visuals |
 | [Microsoft Designer](tools/microsoft_designer.md) | `Free` DALL·E access in a templated design app + Bing Image Creator |
 
 ### Image editing & object work
@@ -391,6 +392,7 @@ Make things - words, images, video, sound.
 | [Topaz Photo AI](tools/topaz_photo.md) | Pro denoise / upscale |
 | [Clipdrop](tools/clipdrop.md) | Background removal, relight, replace |
 | [igly.ai](tools/igly.md) | Browser-based background removal, inpainting, upscaling, and generative fill |
+| [Rao Edits](tools/rao_edits.md) | Reference-image variations, restyles, and AI photo transformations |
 | [ClipSnap](tools/clipsnap.md) | `Free` no-watermark all-in-one toolbox; no signup, no API |
 | [Remove.bg](tools/removebg.md) | One-click background removal |
 | [TinyTools](https://tinytools-smoky.vercel.app/) | `Free` all-in-one browser toolbox: local background removal (WASM, fully offline), OG image gen, SEO tags, favicon, color palette, domain generator + AI cost calculator; no signup |

--- a/tools/rao_edits.md
+++ b/tools/rao_edits.md
@@ -1,0 +1,56 @@
+# Rao Edits: image generation and reference-based editing
+
+Rao Edits sits across the image generation and image editing categories. It is a browser-based workspace for text-to-image generation and reference-image editing, aimed at creators and marketers producing social assets, campaign concepts, thumbnails, and CapCut-oriented visuals.
+
+## What it actually is
+
+A web app at [raoedits.top](https://raoedits.top/) with two closely related workflows:
+
+* Generate an image from a text prompt.
+* Upload a reference image and guide variations, restyles, mood changes, or cleaner concepts with a prompt.
+
+The product currently presents Nano Banana Pro and Gemini 3 Pro as its generation models and positions the editor around fast creative iteration.
+
+## Setup
+
+1. Open [Rao Edits](https://raoedits.top/).
+2. Choose text-to-image or add a reference image.
+3. Describe the subject, composition, style, and intended format.
+4. Generate a result, then refine the prompt or reference until the direction is usable.
+
+## Where it fits day to day
+
+* **Campaign concepts.** Explore several visual directions before committing design time.
+* **Social and thumbnail assets.** Generate source images for posts, videos, and CapCut templates.
+* **Reference-based revisions.** Keep an existing draft as the starting point while changing its mood, styling, or finish.
+* **Fast visual iteration.** Compare prompt variations while a concept is still fluid.
+
+## Gotchas
+
+* It is a cloud web app, not a local or open-source image workflow.
+* Reference-image results still depend on the source image and the specificity of the prompt.
+* It is not a replacement for a layer-based editor when exact masking, typography, or compositing is required.
+* Model availability, credits, and pricing can change; check the current product page before planning a high-volume workflow.
+
+## Alternatives
+
+* For a real-time sketch-and-prompt loop, compare [Krea](krea.md).
+* For professional layer-based compositing, use [Photoshop Generative Fill](photoshop_genfill.md).
+* For focused background removal and relighting utilities, compare [Clipdrop](clipdrop.md).
+* For aesthetic-first generation, compare [Midjourney](midjourney.md).
+
+## FAQ
+
+### What is Rao Edits best for?
+
+Quick browser-based image generation and reference-led variations for social, marketing, and creator workflows.
+
+### Does it support both generation and editing?
+
+Yes. The editor supports text-to-image generation as well as workflows that begin with an uploaded reference image.
+
+## Pointers
+
+* [Rao Edits](https://raoedits.top/)
+* For real-time iteration: [krea.md](krea.md)
+* For a full editing suite: [photoshop_genfill.md](photoshop_genfill.md)


### PR DESCRIPTION
## Summary

- add Rao Edits to the image generation and image editing tables
- add a focused tool page covering its text-to-image and reference-image workflows
- keep claims limited to capabilities presented on the public product page

## Verification

- `https://raoedits.top/` returns HTTP 200 and identifies text-to-image plus reference-image editing
- all relative Markdown links in the new page resolve to existing files
- `git diff --check` passes

Disclosure: this contribution is submitted on behalf of Rao Edits so it can be reviewed as a product submission.