### PR TITLE
Add NotFair to marketing and SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Make things - words, images, video, sound.
 | [Writesonic](tools/writesonic.md) | SEO-focused content + Chatsonic |
 | [Surfer SEO](tools/surfer_seo.md) | SEO content optimization |
 | [Frase](tools/frase.md) | SERP analysis + brief generation |
+| [NotFair](https://github.com/nowork-studio/notfair-plugin) | `OSS` agent skills for SEO, GEO, Google Ads, and Meta Ads with evidence-led, approval-bounded workflows |
 | [Writer](tools/writer.md) | Enterprise content platform; brand governance |
 
 #### Fiction & creative


### PR DESCRIPTION
## Summary

Add NotFair to the Marketing / brand voice / SEO section using the repository's one-tool-per-row format.

NotFair is a public MIT-licensed collection of host-agnostic agent skills for SEO, GEO, Google Ads, and Meta Ads. The one-line description is limited to capabilities documented in the project README: evidence-led workflows and explicit approval boundaries for paid-media work.

## Verification

- Public repository and MIT license are available at the linked source
- The entry adds one tool and one one-line best-for reason
- `git diff --check` passes