### PR TITLE
Add Orkas to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ General-purpose agents that can plan, browse, click, and execute multi-step work
 | [LangGraph](tools/langgraph.md) | `OSS` stateful agent graphs |
 | [Smolagents](tools/smolagents.md) | `OSS` minimal agent framework (HF) |
 | [Letta](tools/letta.md) | `OSS` stateful agents with persistent memory (MemGPT) |
+| [Orkas](https://github.com/Orkas-AI/Orkas) | `OSS` `Local` desktop AI workforce; one Commander coordinates specialist agents |
 | [Tree Ring Memory](tools/tree_ring_memory.md) | `OSS` `Local` memory lifecycle layer for agents; SQLite/FTS recall, audit, redaction, and consolidation |
 | [MultiOn](tools/multion.md) | Browser agent + developer API (Agent Q) |
 | [Skyvern](tools/skyvern.md) | `OSS` vision-grounded browser automation |


### PR DESCRIPTION
Adds one concise Orkas row to Agents & browser automation. The entry identifies it as an open-source, local-first desktop AI workforce coordinated by a Commander.

Validation: duplicate search, canonical link check, and `git diff --check` passed. This is a project-affiliated submission.